### PR TITLE
Do not enforce positivity in get_concentrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,39 @@ jobs:
                 python .ci/generate-example-mech.py test/mechs/sanDiego.cti pyrometheus/thermochem_example.py
                 build_docs
 
+    downstream_tests:
+        strategy:
+            matrix:
+                downstream_project: [mirgecom]
+        name: Tests for downstream project ${{ matrix.downstream_project }}
+        runs-on: ubuntu-latest
+        steps:
+        -   uses: actions/checkout@v2
+        -   name: "Main Script"
+            env:
+                DOWNSTREAM_PROJECT: ${{ matrix.downstream_project }}
+            run: |
+                git clone "https://github.com/illinois-ceesd/$DOWNSTREAM_PROJECT.git"
+                cd "$DOWNSTREAM_PROJECT"
+                echo "*** $DOWNSTREAM_PROJECT version: $(git rev-parse --short HEAD)"
+                sed -i "/egg=pyrometheus/ c git+file://$(readlink -f ..)#egg=pyrometheus" requirements.txt
+                # Avoid slow or complicated tests in downstream projects
+                export PYTEST_ADDOPTS="-k 'not (slowtest or octave or mpi)'"
+                if test "$DOWNSTREAM_PROJECT" = "mirgecom"; then
+                    # can't turn off MPI in mirgecom
+                    sudo apt-get update
+                    sudo apt-get install openmpi-bin libopenmpi-dev
+                    export CONDA_ENVIRONMENT=conda-env.yml
+                else
+                    sed -i "/mpi4py/ d" requirements.txt
+                    export CONDA_ENVIRONMENT=.test-conda-env-py3.yml
+
+                fi
+                curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/master/ci-support.sh
+                . ./ci-support.sh
+                build_py_project_in_conda_env
+
+                export CISUPPORT_PARALLEL_PYTEST=no
+                test_py_project
+
 # vim: sw=4

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,7 +78,7 @@ intersphinx_mapping = {
 
 autoclass_content = "class"
 
-mathjax_config = {
+mathjax3_config = {
     "tex2jax": {
         "inlineMath": [["\\(", "\\)"]],
         "displayMath": [["\\[", "\\]"]],

--- a/pyrometheus/__init__.py
+++ b/pyrometheus/__init__.py
@@ -485,11 +485,7 @@ class Thermochemistry:
         return 1/np.dot(self.iwts, mass_fractions)
 
     def get_concentrations(self, rho, mass_fractions):
-        concs = self.iwts * rho * mass_fractions
-        zero = _pyro_zeros_like(concs[0])
-        for i, conc in enumerate(concs):
-            concs[i] = self.usr_np.where(concs[i] < 0, zero, conc)
-        return concs
+        return self.iwts * rho * mass_fractions
 
     def get_mass_average_property(self, mass_fractions, spec_property):
         return sum([mass_fractions[i] * spec_property[i] * self.iwts[i]


### PR DESCRIPTION
Closes #22.

The reason I think this is reasonable because it's easy to override after the fact:

```py
class Thermochem:
    def get_pressure(self, u):
        return self.get_concentrations(u)**1.4
    
    def get_concentrations(self, u):
        return u/1.5
    
def get_thermochem():
    return Thermochem
    
def do_stuff_with_pyro() :
    tchem_cls = get_thermochem()
    
    class MyThermochem(tchem_cls):
        def get_concentrations(self, u):
            return u/1.5 if u > 0 else 0
    
    tchem = MyThermochem()
    print(tchem.get_pressure(-5))

do_stuff_with_pyro()
```

cc @cmikida2