### PR TITLE
Keep concentration > 0 in get_concentration

### DIFF
--- a/pyrometheus/__init__.py
+++ b/pyrometheus/__init__.py
@@ -492,8 +492,17 @@ class Thermochemistry:
                 %endfor
                 )
 
+    def _pyro_zeros_like(argument):
+        return 0 * argument
+            
     def get_concentrations(self, rho, mass_fractions):
-        return self.iwts * rho * mass_fractions
+        concs = self.iwts * rho * mass_fractions
+
+        # ensure non-negative concentrations
+        zero = _pyro_zeros_like(concs[0])
+        for i, conc in enumerate(concs):
+            concs[i] = self.usr_np.where(concs[i] < 0, zero, concs[i])
+        return concs
 
     def get_mass_average_property(self, mass_fractions, spec_property):
         return sum([mass_fractions[i] * spec_property[i] * self.iwts[i]


### PR DESCRIPTION
chemistry and eos appear to run afoul when the concentration goes below zero

this change does nothing to "correct" the issue, that would require separate filter to drive things in the right, non-negative, direction. Best implemented in another part of the code, or driver.

For now, just keep pyrometheus from considering species mass fractions below zero, as this crashes the code.