### PR TITLE
Mirgecom downstream CI: Use mpi4py from conda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,8 @@ jobs:
                 export PYTEST_ADDOPTS="-k 'not (slowtest or octave or mpi)'"
                 if test "$DOWNSTREAM_PROJECT" = "mirgecom"; then
                     # can't turn off MPI in mirgecom
-                    sudo apt-get update
-                    sudo apt-get install openmpi-bin libopenmpi-dev
                     export CONDA_ENVIRONMENT=conda-env.yml
+                    echo "- mpi4py" >> "$CONDA_ENVIRONMENT"
                 else
                     sed -i "/mpi4py/ d" requirements.txt
                     export CONDA_ENVIRONMENT=.test-conda-env-py3.yml


### PR DESCRIPTION
Fixes mirgecom downstream CI, which is currently broken.